### PR TITLE
Fix "undefined reference to vtable" on Teensy3 & Arduino Due

### DIFF
--- a/rgb_lcd.cpp
+++ b/rgb_lcd.cpp
@@ -45,6 +45,10 @@ void i2c_send_byteS(unsigned char *dta, unsigned char len)
     Wire.endTransmission();                     // stop transmitting
 }
 
+rgb_lcd::rgb_lcd()
+{
+}
+
 void rgb_lcd::begin(uint8_t cols, uint8_t lines, uint8_t dotsize) 
 {
 

--- a/rgb_lcd.h
+++ b/rgb_lcd.h
@@ -90,6 +90,7 @@ class rgb_lcd : public Print
 {
 
 public:
+  rgb_lcd();
 
   void begin(uint8_t cols, uint8_t rows, uint8_t charsize = LCD_5x8DOTS);
 


### PR DESCRIPTION
On 32 bit boards, like Arduino Due and Teensy 3.0, this library gives an error: undefined reference to `vtable for rgb_lcd'

The solution is very simple, just add an empty constructor.
