### PR TITLE
Allow support for the object to specify which wire object to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ Before we use this lcd, we should initialize it. You can use this function:
 
 This means that this lcd has 16 columns and 2 rows.
 
+Optionally you can also specify the character size: LCD_5x10DOTS  or LCD_5x8DOTS which is the default
+
+and for those board who support different Wire objects, which one:  
+
+Example:
+    lcd.begin(16, 2, LCD_5x8DOTS, Wire2);
+
+
 
 ### Change Color of Backlight
 One of Grove - LCD RGB Backlight's most important feature is changing the backlight color. It's very simple; just use the folowing function:

--- a/rgb_lcd.cpp
+++ b/rgb_lcd.cpp
@@ -36,18 +36,18 @@
 
 #include "rgb_lcd.h"
 
-void i2c_send_byte(unsigned char dta) {
-    Wire.beginTransmission(LCD_ADDRESS);        // transmit to device #4
-    Wire.write(dta);                            // sends five bytes
-    Wire.endTransmission();                     // stop transmitting
+void rgb_lcd::i2c_send_byte(unsigned char dta) {
+    _wire->beginTransmission(LCD_ADDRESS);        // transmit to device #4
+    _wire->write(dta);                            // sends five bytes
+    _wire->endTransmission();                     // stop transmitting
 }
 
-void i2c_send_byteS(unsigned char* dta, unsigned char len) {
-    Wire.beginTransmission(LCD_ADDRESS);        // transmit to device #4
+void rgb_lcd::i2c_send_byteS(unsigned char* dta, unsigned char len) {
+    _wire->beginTransmission(LCD_ADDRESS);        // transmit to device #4
     for (int i = 0; i < len; i++) {
-        Wire.write(dta[i]);
+        _wire->write(dta[i]);
     }
-    Wire.endTransmission();                     // stop transmitting
+    _wire->endTransmission();                     // stop transmitting
 }
 
 rgb_lcd::rgb_lcd()
@@ -60,9 +60,10 @@ rgb_lcd::rgb_lcd()
 {
 }
 
-void rgb_lcd::begin(uint8_t cols, uint8_t lines, uint8_t dotsize) {
+void rgb_lcd::begin(uint8_t cols, uint8_t lines, uint8_t dotsize, TwoWire &wire) {
 
-    Wire.begin();
+    _wire = &wire;
+    _wire->begin();
 
     if (lines > 1) {
         _displayfunction |= LCD_2LINE;
@@ -254,10 +255,10 @@ inline size_t rgb_lcd::write(uint8_t value) {
 }
 
 void rgb_lcd::setReg(unsigned char addr, unsigned char dta) {
-    Wire.beginTransmission(RGB_ADDRESS); // transmit to device #4
-    Wire.write(addr);
-    Wire.write(dta);
-    Wire.endTransmission();    // stop transmitting
+    _wire->beginTransmission(RGB_ADDRESS); // transmit to device #4
+    _wire->write(addr);
+    _wire->write(dta);
+    _wire->endTransmission();    // stop transmitting
 }
 
 void rgb_lcd::setRGB(unsigned char r, unsigned char g, unsigned char b) {

--- a/rgb_lcd.h
+++ b/rgb_lcd.h
@@ -34,6 +34,7 @@
 
 #include <inttypes.h>
 #include "Print.h"
+#include <Wire.h>
 
 // Device I2C Arress
 #define LCD_ADDRESS     (0x7c>>1)
@@ -97,7 +98,7 @@ class rgb_lcd : public Print {
   public:
     rgb_lcd();
 
-    void begin(uint8_t cols, uint8_t rows, uint8_t charsize = LCD_5x8DOTS);
+    void begin(uint8_t cols, uint8_t rows, uint8_t charsize = LCD_5x8DOTS, TwoWire &wire = Wire);
 
     void clear();
     void home();
@@ -144,6 +145,8 @@ class rgb_lcd : public Print {
   private:
     void send(uint8_t, uint8_t);
     void setReg(unsigned char addr, unsigned char dta);
+    void i2c_send_byte(unsigned char dta);
+    void i2c_send_byteS(unsigned char* dta, unsigned char len);
 
     uint8_t _displayfunction;
     uint8_t _displaycontrol;
@@ -152,6 +155,8 @@ class rgb_lcd : public Print {
     uint8_t _initialized;
 
     uint8_t _numlines, _currline;
+
+    TwoWire *_wire;
 };
 
 #endif


### PR DESCRIPTION
Added optional parameter to begin method to allow you to specify which wire
object to use as many devices now support more than one.

Added member variable to class for it, also change implementation to use,   this.  Added two functions in .cpp to be private member functions as you could have more than one of these displays on a board and have them on different busses.

Example Usage:
    lcd.begin(16, 2, LCD_5x8DOTS, Wire2);

Was discussed and tried in the Teensy Forum:
https://forum.pjrc.com/threads/69541-problem-with-using-SCL2-SDA2-with-Teensy-4-1?p=300317&viewfull=1#post300317
